### PR TITLE
Fully memory driven (or temp)

### DIFF
--- a/novelsave/settings.py
+++ b/novelsave/settings.py
@@ -1,11 +1,20 @@
 import mimetypes
+import os
+
+import dotenv
 from pathlib import Path
 
 from appdirs import user_config_dir
 from tqdm import tqdm
 
+
 NAME = "novelsave"
 AUTHOR = "Mensch272"
+
+# load environment variables
+dotenv.load_dotenv()  # take environment variables from .env
+
+STORAGE = os.environ.get("STORAGE") or "filesystem"
 
 # base project directory
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/novelsave/settings.py
+++ b/novelsave/settings.py
@@ -1,12 +1,11 @@
 import mimetypes
 import os
-
-import dotenv
 from pathlib import Path
 
+import dotenv
+import fs
 from appdirs import user_config_dir
 from tqdm import tqdm
-
 
 NAME = "novelsave"
 AUTHOR = "Mensch272"
@@ -15,27 +14,37 @@ AUTHOR = "Mensch272"
 dotenv.load_dotenv()  # take environment variables from .env
 
 STORAGE = os.environ.get("STORAGE") or "filesystem"
+LOGTOFILE = bool(int(os.environ.get("LOGTOFILE") or "1"))
+
+fs_storage = {
+    "filesystem": "osfs",
+    "memory": "mem",
+}
 
 # base project directory
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = fs.open_fs(
+    fs_storage[STORAGE] + "://" + str(Path(__file__).resolve().parent.parent)
+)
 
-STATIC_DIR = BASE_DIR / "novelsave/resources"
+STATIC_DIR = "novelsave/resources"
 
 # operating system specific configuration file
 # config directory is used to place logs, config, cache
-CONFIG_DIR = Path(user_config_dir(NAME, AUTHOR))
-CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-CONFIG_FILE = CONFIG_DIR / "config.json"
+CONFIG_PATH = Path(user_config_dir(NAME, AUTHOR))
+CONFIG_DIR = fs.open_fs(fs_storage[STORAGE] + "://" + str(CONFIG_PATH))
+CONFIG_FILE = "config.json"
 
-DATA_DIR = CONFIG_DIR / "data"
-DATA_DIR.mkdir(parents=True, exist_ok=True)
+DATA_DIR = fs.open_fs(fs_storage[STORAGE] + "://" + str(CONFIG_PATH / "data"))
 
-DATABASE_FILE = (CONFIG_DIR / "data.sqlite").resolve()
-DATABASE_URL = "sqlite:///" + str(DATABASE_FILE)
+if STORAGE == "memory":
+    DATABASE_URL = "sqlite:///:memory:"
+else:
+    DATABASE_FILE = (CONFIG_PATH / "data.sqlite").resolve()
+    DATABASE_URL = "sqlite:///" + str(DATABASE_FILE)
 
 # default novel directory, where packaged files such
 # as epub and pdf are stored.
-NOVEL_DIR = Path.home() / "novels"
+NOVEL_DIR = fs.open_fs(fs_storage[STORAGE] + "://" + str(Path.home()))
 
 # the following map defines how files are stored
 # by further subdivision into sub-folders
@@ -61,15 +70,19 @@ LOGGER_CONFIG = {
             "backtrace": False,
             "diagnose": False,
         },
+    ],
+}
+
+if LOGTOFILE:
+    LOGGER_CONFIG["handlers"] += [
         {
-            "sink": CONFIG_DIR / "logs" / "{time}.log",
+            "sink": CONFIG_PATH / "logs" / "{time}.log",
             "level": "TRACE",
             "retention": "2 days",
             "compression": "zip",
             "encoding": "utf-8",
-        },
-    ],
-}
+        }
+    ]
 
 TQDM_CONFIG = {"ncols": 80, "bar_format": "{percentage:3.0f}% |{bar}{r_bar}"}
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -238,6 +238,22 @@ docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=
 testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
+name = "fs"
+version = "2.4.13"
+description = "Python's filesystem abstraction layer"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+appdirs = ">=1.4.3,<1.5.0"
+pytz = "*"
+six = ">=1.10,<2.0"
+
+[package.extras]
+scandir = ["scandir (>=1.5,<2.0)"]
+
+[[package]]
 name = "greenlet"
 version = "1.1.2"
 description = "Lightweight in-process concurrent programming"
@@ -565,6 +581,25 @@ pytest = ">=5.0"
 dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
+name = "python-dotenv"
+version = "0.19.2"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
+name = "pytz"
+version = "2021.3"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.0"
 description = ""
@@ -762,7 +797,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "7b13aa79845650bf7b8dc348189253d1d83785b5fde86f96d3940556aefd8464"
+content-hash = "46f6b8614210e77a05e9ba6a21beb9205318bd391cdeb53ea56e2f6839d188a0"
 
 [metadata.files]
 alembic = [
@@ -942,6 +977,10 @@ ebooklib = [
 filelock = [
     {file = "filelock-3.3.2-py3-none-any.whl", hash = "sha256:bb2a1c717df74c48a2d00ed625e5a66f8572a3a30baacb7657add1d7bac4097b"},
     {file = "filelock-3.3.2.tar.gz", hash = "sha256:7afc856f74fa7006a289fd10fa840e1eebd8bbff6bffb69c26c54a0512ea8cf8"},
+]
+fs = [
+    {file = "fs-2.4.13-py2.py3-none-any.whl", hash = "sha256:1d10cc8f9c55fbcf7b23775289a13f6796dca7acd5a135c379f49e87a56a7230"},
+    {file = "fs-2.4.13.tar.gz", hash = "sha256:caab4dc1561d63c92f36ee78976f6a4a01381830d8420ce34a78d4f1bb1dc95f"},
 ]
 greenlet = [
     {file = "greenlet-1.1.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:58df5c2a0e293bf665a51f8a100d3e9956febfbf1d9aaf8c0677cf70218910c6"},
@@ -1263,6 +1302,14 @@ pytest = [
 pytest-mock = [
     {file = "pytest-mock-3.6.1.tar.gz", hash = "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"},
     {file = "pytest_mock-3.6.1-py3-none-any.whl", hash = "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.19.2.tar.gz", hash = "sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f"},
+    {file = "python_dotenv-0.19.2-py2.py3-none-any.whl", hash = "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3"},
+]
+pytz = [
+    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
+    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
 ]
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ browser-cookie3 = "^0.13.0"
 tqdm = "^4.62.3"
 Mako = "^1.1.5"
 tabulate = "^0.8.9"
+fs = "^2.4.13"
+python-dotenv = "^0.19.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
This feature aims to allow `novelsave` to run fully in memory without using the filesystem. This is a step towards adding bots and a possible website with out storing the downloaded files long term.

This pull request also add the ability to use a temporary location instead of memory for when large number of `novelsave` instances may be run in succession.

The viability of this system is still being evaluated, as such it cannot be guaranteed to be merge into `main` branch.